### PR TITLE
Fix type casting bug reported by user over email

### DIFF
--- a/pymodulo/SpatialStratification/gridding.js
+++ b/pymodulo/SpatialStratification/gridding.js
@@ -11,7 +11,7 @@ bbox = bbox.map((val, i) => {
 });
 // bbox is now something like: [77.52021789550781, 12.91823730850926, 77.68020629882812, 13.02997975435598]
 
-let cellSide = parseInt(process.argv[6]);
+let cellSide = Number(process.argv[6]);
 let options = {units: 'kilometers'};
 
 // use turfjs to get the grid

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pymodulo",
-    version="0.0.9",
+    version="0.1.0",
     author="Dhruv Agarwal",
     author_email="dhruv.agarwal@alumni.ashoka.edu.in",
     description="Vehicle selection for drive-by sensing deployments to maximize coverage",


### PR DESCRIPTION
We were type casting because the input (`process.argv[6]`) would be a string while we needed it to be a number. However, using `parseInt` restricts this to integers. For example, the user tried using 0.1 as the cell side length, which would be parsed as 0. This led to downstream errors in Turf.js.

The fix is simple: use a more generic type caster (`Number`). Fixes #2.